### PR TITLE
build: make copy-to-clipboard an explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release": "npm run build && auto shipit"
   },
   "dependencies": {
+    "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",
     "escape-html": "^1.0.3",
     "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
## Motivation

When using this plugin inside a yarn 2 project, an error message is thrown because `copy-to-clipboard` was referenced even though it's not part of the package's dependencies.

https://github.com/storybookjs/addon-knobs/blob/127018283737fb71bdc14bc8daac808e247dcede/src/components/Panel.tsx#L6

Project owners can manually install copy-to-clipboard themselves, but including it within the library should saves people from an extra error message.

## Notes

- This should not conflict with the version of `copy-to-clipboard` currently in the mainline storybook branch. https://github.com/storybookjs/storybook/blob/3c076a333a122feeb07af520c28195358bab68ba/lib/ui/package.json#L54 . I think this import is why the library works indirectly (the issue just wasn't flagged until using yarn 2, since it's stricter about imports).