### PR TITLE
fix: Add missing @storybook/client-api peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "peerDependencies": {
     "@storybook/addons": "^6.4.0",
     "@storybook/api": "^6.4.0",
+    "@storybook/client-api": "^6.4.0",
     "@storybook/components": "^6.4.0",
     "@storybook/core-events": "^6.4.0",
     "@storybook/theming": "^6.4.0",


### PR DESCRIPTION
We require this at runtime, so it has to be more than just a dev
dependency.