### PR TITLE
Chore: (Docs) Updates link for support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Storybook Addon Knobs allow you to edit props dynamically using the Storybook UI.
 You can also use Knobs as a dynamic variable inside stories in [Storybook](https://storybook.js.org).
 
-[Framework Support](https://github.com/storybookjs/storybook/blob/master/ADDONS_SUPPORT.md).
+[Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support).
 
 This is what Knobs looks like:
 


### PR DESCRIPTION
With this small pull request, the Framework support link is updated to its proper location as the Addon Support table is no longer a source of truth.

Addresses #17150 

I'm aware that knobs is deprecated, but this prevents users from getting a 404 when clicking the link