### PR TITLE
[Hotfix] Seeing knobs from previously selected story 

### DIFF
--- a/src/registerKnobs.ts
+++ b/src/registerKnobs.ts
@@ -68,6 +68,7 @@ function resetKnobsAndForceReRender() {
 }
 
 function disconnectCallbacks() {
+  knobStore.reset();
   const channel = addons.getChannel();
   channel.removeListener(CHANGE, knobChanged);
   channel.removeListener(CLICK, knobClicked);


### PR DESCRIPTION
Original issue: https://github.com/storybookjs/addon-knobs/issues/19

**Short description:**
In Storybook v6.4 `disconnectCallbacks` is invoked before `STORY_CHANGED` event has been emitted. As the result the knobs are not being reset. 
**Fix:** reset knobs in `disconnectCallbacks` function.