### PR TITLE
Upgrade Node in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Prepare repository
         run: git fetch --unshallow --tags
 
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           cache: yarn
       - name: install
         run: |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ First of all, you need to install Knobs into your project as a dev dependency.
 yarn add @storybook/addon-knobs --dev
 ```
 
+The latest version of this addon supports Storybook v7. If you're using a previous version of Storybook you need to install the matching version of this addon, eg `@storybook/addon-knobs@6.4.0`.
+
 within `.storybook/main.js`:
 
 ```js


### PR DESCRIPTION
The Node version in GitHub Action didn't match Storybook 7 requirements, causing it to fail.