### PR TITLE
build: make storybook peer dependency less strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,11 +72,11 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@storybook/addons": "7.0.0",
-    "@storybook/api": "7.0.0",
-    "@storybook/components": "7.0.0",
-    "@storybook/core-events": "7.0.0",
-    "@storybook/theming": "7.0.0",
+    "@storybook/addons": "^7.0.0",
+    "@storybook/api": "^7.0.0",
+    "@storybook/components": "^7.0.0",
+    "@storybook/core-events": "^7.0.0",
+    "@storybook/theming": "^7.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },


### PR DESCRIPTION
The dependencies now are too strict and cause warnings when consumers are not on an exactly matching version. This fixes that.