### PR TITLE
refactor: remove usage of deprecated addons package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "release": "npm run build && auto shipit"
   },
   "dependencies": {
+    "@storybook/preview-api": "^7.0.0",
     "copy-to-clipboard": "^3.3.3",
     "core-js": "^3.29.0",
     "escape-html": "^1.0.3",
@@ -76,7 +77,6 @@
     "@storybook/components": "^7.0.0",
     "@storybook/core-events": "^7.0.0",
     "@storybook/theming": "^7.0.0",
-    "@storybook/preview-api": "^7.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "release": "npm run build && auto shipit"
   },
   "dependencies": {
-    "@storybook/preview-api": "^7.0.0",
     "copy-to-clipboard": "^3.3.3",
     "core-js": "^3.29.0",
     "escape-html": "^1.0.3",
@@ -77,6 +76,7 @@
     "@storybook/components": "^7.0.0",
     "@storybook/core-events": "^7.0.0",
     "@storybook/theming": "^7.0.0",
+    "@storybook/preview-api": "^7.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@storybook/components": "^7.0.0",
     "@storybook/core-events": "^7.0.0",
     "@storybook/theming": "^7.0.0",
+    "@storybook/preview-api": "^7.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@storybook/addons": "^7.0.0",
     "@storybook/api": "^7.0.0",
     "@storybook/components": "^7.0.0",
     "@storybook/core-events": "^7.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import { makeDecorator, addons } from '@storybook/addons';
-
+import { makeDecorator, addons } from '@storybook/preview-api';
 import { SET_OPTIONS } from './shared';
 import { manager, registerKnobs } from './registerKnobs';
 import { Knob, KnobType, Mutable } from './type-defs';

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { addons } from '@storybook/addons';
+import { addons } from '@storybook/manager-api';
 import Panel from './components/Panel';
 import { ADDON_ID, PANEL_ID, PARAM_KEY } from './shared';
 import { createTitleListener } from './title';

--- a/src/registerKnobs.ts
+++ b/src/registerKnobs.ts
@@ -1,5 +1,4 @@
-import { addons } from '@storybook/addons';
-import { useEffect } from '@storybook/preview-api';
+import { useEffect, addons } from '@storybook/preview-api';
 import { STORY_CHANGED, FORCE_RE_RENDER } from '@storybook/core-events';
 import debounce from 'lodash/debounce';
 


### PR DESCRIPTION
See https://github.com/storybookjs/storybook/issues/23525#issuecomment-1642954711. This peer dependency can cause errors, and migrating away from it doesn't seem too hard.