### PR TITLE
Remove key from panel render props

### DIFF
--- a/src/register.tsx
+++ b/src/register.tsx
@@ -7,7 +7,7 @@ import { createTitleListener } from './title';
 addons.register(ADDON_ID, (api) => {
   addons.addPanel(PANEL_ID, {
     title: createTitleListener(api),
-    render: ({ active, key }) => <Panel api={api} key={key} active={active} />,
+    render: ({ active }) => <Panel api={api} active={active} />,
     paramKey: PARAM_KEY,
   });
 });


### PR DESCRIPTION
Equivalent to https://github.com/storybookjs/storybook/commit/9f79059:
> addon render function are now called like React elements, thus keys are no longer needed

Fixes this warning in dev console:

    Warning: render: `key` is not a prop. Trying to access it will result in `undefined` being returned.
    If you need to access the same value within the child component, you should pass it as a different prop.