### PR TITLE
Add @storybook/preview-api in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@storybook/manager-api": "^8.0.0",
     "@storybook/components": "^8.0.0",
     "@storybook/core-events": "^8.0.0",
+    "@storybook/preview-api": "^8.0.0",
     "@storybook/theming": "^8.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
`@storybook/preview-api` is used in https://github.com/storybookjs/addon-knobs/blob/main/src/index.ts#L1 so this PR just adds that `peerDep` in.